### PR TITLE
Fix Rich markup rendering for path resolvers

### DIFF
--- a/ocebuild_cli/commands/lock.py
+++ b/ocebuild_cli/commands/lock.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Tuple, Union
 
 import click
 from rich import box
+from rich.markup import escape
 from rich.table import Table
 
 from ocebuild.parsers.yaml import parse_yaml
@@ -45,20 +46,30 @@ def rich_resolver(resolver: ResolverType,
   elif 'path' in resolver_props:
     path_ = Path(resolver.path)
     # _checksum = resolver_props['__resolver'].checksum
-    name, resolution_str = resolution.split('@file:')
-    resolution_str = f'file:{resolution_str}' \
-      .replace(':', '[/dim cyan][dim]:[/dim][dim yellow]', 1) \
-      .replace(path_.name, f'[bold yellow]{path_.name}', 1) \
-      .replace('#', '[/bold yellow][/dim yellow][dim]#[dim bold]') \
-      .replace('=', '[/dim bold][dim]=')
+    name, resolution_str = resolution.split('@file:', 1)
+    name = escape(name)
+    resolution_str = escape(f'file:{resolution_str}') \
+      .replace(':', '[/dim cyan][dim]:[/dim][dim yellow]', 1)
+    path_name = escape(path_.name)
+    if path_name and path_name in resolution_str:
+      resolution_str = resolution_str.replace(
+        path_name, f'[bold yellow]{path_name}', 1)
+      hash_style = '[/bold yellow][/dim yellow][dim]#[dim bold]'
+    else:
+      # Compiled artifacts can have a different suffix than their specifier.
+      hash_style = '[/dim yellow][dim]#[dim bold]'
+    resolution_str = resolution_str \
+      .replace('#', hash_style, 1) \
+      .replace('=', '[/dim bold][dim]=', 1)
   elif 'url' in resolver_props:
     has_version_ = ':' in resolution
     close_color_ = "[/green]" if has_version_ else "[/dim cyan]"
-    name, resolution_str = resolution.split('@')
-    resolution_str = resolution_str \
+    name, resolution_str = resolution.split('@', 1)
+    name = escape(name)
+    resolution_str = escape(resolution_str) \
       .replace(':', '[/dim cyan][dim]:[/dim][green]', 1) \
-      .replace('#', f'{ close_color_ }[dim]#[dim bold]') \
-      .replace('=', '[/dim bold][dim]=')
+      .replace('#', f'{ close_color_ }[dim]#[dim bold]', 1) \
+      .replace('=', '[/dim bold][dim]=', 1)
 
   return f"[cyan]{name}[/cyan][dim cyan]@{resolution_str}"
 

--- a/ocebuild_cli/commands/lock_test.py
+++ b/ocebuild_cli/commands/lock_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+## @file
+# Copyright (c) 2026, The OCE Build Authors. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+##
+"""Tests for the lock command."""
+
+from types import SimpleNamespace
+
+from rich.markup import render
+
+from .lock import rich_resolver
+
+
+def test_rich_resolver_handles_generated_path_name():
+  """Generated artifacts may not share the source specifier's filename."""
+  resolution = \
+    'SSDT-ALS0@file:ACPI/SSDT-ALS0.dsl#checksum=abc123'
+  resolver = SimpleNamespace(path='ACPI/SSDT-ALS0.aml')
+
+  formatted = rich_resolver(resolver, {'path': resolver.path}, resolution)
+
+  assert render(formatted).plain == resolution
+
+
+def test_rich_resolver_escapes_path_markup():
+  """Path text containing Rich markup syntax must remain literal."""
+  resolution = \
+    'Example@file:Kexts/[release]/Example.kext#checksum=abc123'
+  resolver = SimpleNamespace(path='Kexts/[release]/Example.kext')
+
+  formatted = rich_resolver(resolver, {'path': resolver.path}, resolution)
+
+  assert render(formatted).plain == resolution


### PR DESCRIPTION
Fixes #25.

### What changed

- Escape dynamic resolver names and path/URL resolution text before adding Rich styles.
- Only close the bold filename style when the resolved filename was actually found and highlighted.
- Limit delimiter replacements/splits to the intended first occurrence.
- Add regressions for generated SSDT paths where `.aml` differs from the `.dsl` specifier and for literal Rich markup characters in paths.

### Why

The previous formatter always inserted `[/bold yellow]` before a path checksum, even if replacing `path_.name` never opened that tag. Compiled SSDTs trigger this because the resolver artifact can be `SSDT-ALS0.aml` while the resolution string contains `SSDT-ALS0.dsl`.

Escaping is also necessary because resolver names and paths are data, not Rich markup.

### Validation

- Full suite: `48 passed` on Python 3.13.
- New regression tests: `2 passed` on the project's minimum Python 3.8 with `graphlib-backport`.
- Full real-world OpenCore build: 41 resolver entries processed, 39 entries extracted, config updated successfully; the former verbose lock-table `MarkupError` did not recur.
- `git diff --check` passes.
